### PR TITLE
Fix callback authentication

### DIFF
--- a/ShippingEasy/ShippingEasy.csproj
+++ b/ShippingEasy/ShippingEasy.csproj
@@ -42,7 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authenticator.cs" />
-    <Compile Include="Properties\BuildInfo.cs" />
     <Compile Include="Responses\ApiResponse.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="Connection.cs" />

--- a/ShippingEasy/Signature.cs
+++ b/ShippingEasy/Signature.cs
@@ -46,7 +46,7 @@ namespace ShippingEasy
                 _path,
                 combinedParameters,
                 _body
-                }.Where(component => !String.IsNullOrWhiteSpace(component))
+                }
             );
         }
 


### PR DESCRIPTION
Fixes a bug where webhook callbacks that contained no querystring parameters other than api_signature would fail. This is because the request is signed without stripping out this extra parameter. If a request contains no querystring parameters, it is signed like this:

POST&/my/url&&{"shipment":

Note the two ampersands(&). Even though there are no querystring parameters, this should still be the string that is signed.